### PR TITLE
Deploy on push to source branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,19 @@ jobs:
         env:
           CI: true
 
-      - name: Run E2E tests
+      - name: run E2E tests
         uses: cypress-io/github-action@v1
         with:
           install: false
           build: yarn build
           start: yarn serve
           wait-on: "http://localhost:4000"
+
+      - name: deploy
+        if: github.ref == 'refs/heads/source'
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: master
+          FOLDER: public
+          CLEAN: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
+
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12.x
 
       - name: install and cache dependencies
         uses: cypress-io/github-action@v1


### PR DESCRIPTION
#38

I removed the build matrix because this repository doesn't need testing with multiple Node.js versions and multiple Node.js versions can mess up the website by trying to deploy at the same time.