### PR TITLE
Fix image placeholder

### DIFF
--- a/lib/transformers/imageopt.js
+++ b/lib/transformers/imageopt.js
@@ -30,6 +30,20 @@ const imageOutputPathOptions = {
   outputDir: "./public/cached/"
 };
 
+// Escapes SVG for Data URI, which results in smaller size than base64.
+const dataUriEscapeMap = {
+  "#": "%23",
+  "%": "%25",
+  ":": "%3A",
+  "<": "%3C",
+  ">": "%3E",
+  '"': "'"
+};
+const dataUriEscapePattern = new RegExp(
+  Object.keys(dataUriEscapeMap).join("|"),
+  "g"
+);
+
 async function handleImg(img) {
   const alt = img.getAttribute("alt");
   let src = img.getAttribute("src");
@@ -74,14 +88,23 @@ async function handleImg(img) {
     return;
   }
   const placeholder = await createBlurryPlaceholder(src);
-  img.parentNode.innerHTML = Image.generateHTML(stats, {
+  const parentNode = img.parentNode;
+  parentNode.innerHTML = Image.generateHTML(stats, {
     alt,
     // On mobile, it's full width minus 20px padding x 2.
     // On bigger screens, it's fixed.
     sizes: "(max-width: 767px) calc(100vw - 40px), 700px",
     loading: "lazy",
     decoding: "async",
-    style: `background-size: cover; background-image: url('${placeholder}')`
+    style:
+      // Escapes double quotes in the attribute value so that
+      // `Image.generateHTML` can safely wrap the value with double quotes.
+      // We can't use single quotes instead of `&quot;` because `placeholder`
+      // has single quotes while it doesn't have double quotes.
+      `background-size: cover; background-image: url("${placeholder}")`.replaceAll(
+        '"',
+        "&quot;"
+      )
   });
 }
 
@@ -122,7 +145,12 @@ async function createBlurryPlaceholder(src) {
       xlink:href="${pngDataUri}">
     </image>
   </svg>`;
-  return dataUriParser.format(".svg", svg).content;
+  return (
+    "data:image/svg+xml;charset=utf-8," +
+    svg
+      .replace(/\s+/g, " ")
+      .replace(dataUriEscapePattern, char => dataUriEscapeMap[char])
+  );
 }
 
 async function imageopt(content, outputPath) {

--- a/lib/transformers/imageopt.js
+++ b/lib/transformers/imageopt.js
@@ -88,8 +88,7 @@ async function handleImg(img) {
     return;
   }
   const placeholder = await createBlurryPlaceholder(src);
-  const parentNode = img.parentNode;
-  parentNode.innerHTML = Image.generateHTML(stats, {
+  img.parentNode.innerHTML = Image.generateHTML(stats, {
     alt,
     // On mobile, it's full width minus 20px padding x 2.
     // On bigger screens, it's fixed.


### PR DESCRIPTION
The placeholder had an incorrect MIME type (PNG) where it should have SVG. `datauri/parser` can't generate SVG data URI.

Fixes #96